### PR TITLE
Backport of the location filter fix

### DIFF
--- a/src/Controller/OpenyMemberships.php
+++ b/src/Controller/OpenyMemberships.php
@@ -292,6 +292,7 @@ class OpenyMemberships extends ControllerBase {
     if ($branch) {
       $orGroup->condition('field_product_branch', $branch->id());
     }
+    $query->condition($orGroup);
     $ids = $query->execute();
     $products = [];
     foreach ($ids as $id) {


### PR DESCRIPTION
Filtering by branch was not working at the branch selector step of the memberships builder.
We've fixed this and backporting it back to the module.