### PR TITLE
fix: Symfony mailer - allow 9.3 core

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ You need to build styles using this commands
 `npm install`
 `npm run scss-build`
 
+## Upgrade to 2.4 version
+
+Release 2.3 (https://github.com/ymcatwincities/openy_memberships/releases/tag/2.3) is needed as an intermediate state for the upgrade path.
+In order to uninstall swiftmailer - upgrade to the 2.3 release and uninstall the module from your Drupal.
+Once uninstalled - proceed with upgrading to the 2.4 version of Open Y Memberships
+
 ## Demo content for Memberships framework
 
 To install the demo content, please do next steps:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/paragraph_skins": "^2.0",
         "openy/commerce_cart_api": "dev-8.x-1.x",
         "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
-        "drupal/webform:": "^6.0 || ^ 6.1"
+        "drupal/webform:": "^6.0 || ^6.1"
     },
     "require-dev": {
         "drupal/swiftmailer": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "openy/openy_block_modal": "^1.0",
         "drupal/paragraph_skins": "^2.0",
         "openy/commerce_cart_api": "dev-8.x-1.x",
-        "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
-        "drupal/mailsystem": "~4.3"
+        "drupal/symfony_mailer": "^1.0@alpha || ^1.0"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/paragraph_skins": "^2.0",
         "openy/commerce_cart_api": "dev-8.x-1.x",
         "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
-        "drupal/webform:": "^6.0 || ^6.1",
+        "drupal/webform": "^6.1",
         "drupal/mailsystem": "~4.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         "drupal/paragraph_skins": "^2.0",
         "openy/commerce_cart_api": "dev-8.x-1.x",
         "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
-        "drupal/webform:": "^6.0 || ^6.1"
+        "drupal/webform:": "^6.0 || ^6.1",
+        "drupal/mailsystem": "~4.3"
     },
     "require-dev": {
-        "drupal/swiftmailer": "^2.0",
-        "drupal/mailsystem": "~4.3"
+        "drupal/swiftmailer": "^2.0"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "openy/openy_block_modal": "^1.0",
         "drupal/paragraph_skins": "^2.0",
         "openy/commerce_cart_api": "dev-8.x-1.x",
-        "drupal/symfony_mailer": "^1.0@alpha || ^1.0"
+        "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
+        "drupal/webform:": "^6.0 || ^ 6.1"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,10 @@
         "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
         "drupal/webform:": "^6.0 || ^ 6.1"
     },
+    "require-dev": {
+        "drupal/swiftmailer": "^2.0",
+        "drupal/mailsystem": "~4.3"
+    },
     "extra": {
         "patches": {
             "openy/commerce_cart_api": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "openy/openy_block_modal": "^1.0",
         "drupal/paragraph_skins": "^2.0",
         "openy/commerce_cart_api": "dev-8.x-1.x",
-        "drupal/swiftmailer": "^2.0",
+        "drupal/symfony_mailer": "^1.0@alpha || ^1.0",
         "drupal/mailsystem": "~4.3"
     },
     "extra": {

--- a/config/install/symfony_mailer.mailer_policy.openy_memberships.yml
+++ b/config/install/symfony_mailer.mailer_policy.openy_memberships.yml
@@ -1,4 +1,3 @@
-uuid: 6e018f12-6ce4-483d-846c-4a42b354869f
 langcode: en
 status: true
 dependencies:

--- a/config/install/symfony_mailer.mailer_policy.openy_memberships.yml
+++ b/config/install/symfony_mailer.mailer_policy.openy_memberships.yml
@@ -1,0 +1,11 @@
+uuid: 6e018f12-6ce4-483d-846c-4a42b354869f
+langcode: en
+status: true
+dependencies:
+  module:
+    - openy_memberships
+id: openy_memberships
+configuration:
+  mailer_default_headers: {  }
+  mailer_inline_css: {  }
+  mailer_url_to_absolute: {  }

--- a/config/install/symfony_mailer.mailer_policy.openy_memberships.yml
+++ b/config/install/symfony_mailer.mailer_policy.openy_memberships.yml
@@ -1,3 +1,4 @@
+uuid: 6e018f12-6ce4-483d-846c-4a42b354869f
 langcode: en
 status: true
 dependencies:

--- a/openy_memberships.info.yml
+++ b/openy_memberships.info.yml
@@ -38,6 +38,6 @@ dependencies:
   - openy_prgf_block_container
   - openy_prgf_sidebar_menu
   - paragraph_skins
-  #- mailsystem
+  - mailsystem
   - symfony_mailer
 core_incompatible: false

--- a/openy_memberships.info.yml
+++ b/openy_memberships.info.yml
@@ -1,7 +1,7 @@
 name: 'Open Y Memberships'
 description: 'Provides the functionality of Open Y Memberships.'
 type: module
-version: 2.2
+version: 2.4
 core_version_requirement: ^8 || ^9
 dependencies:
   - address

--- a/openy_memberships.info.yml
+++ b/openy_memberships.info.yml
@@ -39,5 +39,5 @@ dependencies:
   - openy_prgf_sidebar_menu
   - paragraph_skins
   - mailsystem
-  - swiftmailer
+  - symfony_mailer
 core_incompatible: false

--- a/openy_memberships.info.yml
+++ b/openy_memberships.info.yml
@@ -38,6 +38,6 @@ dependencies:
   - openy_prgf_block_container
   - openy_prgf_sidebar_menu
   - paragraph_skins
-  - mailsystem
+  #- mailsystem
   - symfony_mailer
 core_incompatible: false


### PR DESCRIPTION
Check https://sandbox-carnation-std-membership-framework-d9.openy.org/

Release 2.3 (https://github.com/ymcatwincities/openy_memberships/releases/tag/2.3) is needed as an intermediate state for the upgrade path.
In order to uninstall swiftmailer - upgrade to the 2.3 release and uninstall the module from your Drupal.
Once uninstalled - proceed with upgrading to the 2.4 version of Open Y Memberships


Default Policy for openy_memberships for symfony_mailer is predefined
![image](https://user-images.githubusercontent.com/563412/145842836-e7faa94c-7caa-4629-9bd8-33dc9e9fdd42.png)
