### PR TITLE
fix: Fix email for anonymous user

### DIFF
--- a/src/Controller/OpenyMemberships.php
+++ b/src/Controller/OpenyMemberships.php
@@ -120,7 +120,7 @@ class OpenyMemberships extends ControllerBase {
       $container->get('renderer'),
       $container->get('plugin.manager.mail'),
       $container->get('openy_memberships_pdf_generator'),
-      $container->get('email.validator)
+      $container->get('email.validator')
     );
   }
 

--- a/src/Controller/OpenyMemberships.php
+++ b/src/Controller/OpenyMemberships.php
@@ -558,10 +558,10 @@ class OpenyMemberships extends ControllerBase {
     $user_email = $order->get('mail')->getValue()[0]['value'];
     $store_email = $store->getEmail();
     
-    if ($this->emailValidator->isValid($user_email) && $this->emailValidator->isValid($store_email)) {
+    if ($user_email && $this->emailValidator->isValid($user_email) && $store_email && $this->emailValidator->isValid($store_email)) {
       $to = implode(', ', [$store_email, $user_email]);
     }
-    elseif ($this->emailValidator->isValid($store_email)) {
+    elseif ($store_email && $this->emailValidator->isValid($store_email)) {
       $to = $store->getEmail();
     }
     else {


### PR DESCRIPTION
Addresses: https://openy.atlassian.net/browse/MAINTAIN-217?focusedCommentId=13695

Anonymous user has no email, thus PHPMailer throws Exception.

We need to ensure we are properly forming a list of emails without trailing comma - see https://3v4l.org/6lkjd

```sh
[Fri Jan 21 13:12:22.833796 2022] [php7:notice] [pid 1374] [client 178.54.63.218:63273] Uncaught PHP Exception PHPMailer\\PHPMailer\\Exception: "Invalid address:  (to): " at /home/jenkins/workspace/SANDBOX_LILY_STANDARD_MEMBERSHIP_FRAMEWORK/build/vendor/phpmailer/phpmailer/src/PHPMailer.php line 1092, referer: https://sandbox-lily-std-membership-framework.openy.org/membership-builder
```

Introduced in https://github.com/ymcatwincities/openy_memberships/pull/40

https://user-images.githubusercontent.com/563412/150541381-c42953a7-578c-43ca-8742-9bed5c3854e1.mp4

